### PR TITLE
#74: Migrate to PyTest

### DIFF
--- a/.github/workflows/test-and-release-rkd.yaml
+++ b/.github/workflows/test-and-release-rkd.yaml
@@ -30,6 +30,14 @@ jobs:
             - name: Run RKD tests on Python ${{ matrix.python-version }}
               run: "make tests"
 
+            - name: Archive RKD tests results
+              uses: dorny/test-reporter@v1
+              if: always()
+              with:
+                  name: "[${{ matrix.python-version }}] RKD tests"
+                  path: build/tests.xml
+                  reporter: java-junit
+
             - name: Run rkd_python tests on Python ${{ matrix.python-version }}
               run: "cd subpackages/rkd_python && make tests"
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TEST_OPTS=
 
 ## Run tests
 tests: refresh_git
-	RKD_BIN=rkd PYTHONPATH="$$(pwd):$$(pwd)/subpackages/rkd_python" pytest ./test --junitxml=build/tests.xml
+	RKD_BIN="python -m rkd" PYTHONPATH="$$(pwd):$$(pwd)/subpackages/rkd_python" pytest ./test --junitxml=build/tests.xml
 
 ## Release
 release: package publish

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ TEST_OPTS=
 
 ## Run tests
 tests: refresh_git
-	export PYTHONPATH="$$(pwd):$$(pwd)/subpackages/rkd_python"; \
-	python3 -m unittest discover -s ./test ${TEST_OPTS}
+	RKD_BIN=rkd PYTHONPATH="$(pwd):$(pwd)/subpackages/rkd_python" pytest ./test --junitxml=build/tests.xml
 
 ## Release
 release: package publish

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TEST_OPTS=
 
 ## Run tests
 tests: refresh_git
-	RKD_BIN=rkd PYTHONPATH="$(pwd):$(pwd)/subpackages/rkd_python" pytest ./test --junitxml=build/tests.xml
+	RKD_BIN=rkd PYTHONPATH="$$(pwd):$$(pwd)/subpackages/rkd_python" pytest ./test --junitxml=build/tests.xml
 
 ## Release
 release: package publish

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+jsonschema = ">=3.2.0"
+pbr = ">=5.4.5"
+python-dotenv = "==0.13.0"
+tabulate = "==0.8.7"
+Jinja2 = ">=2.11"
+PyYAML = ">=5.3.1"
+
+[dev-packages]
+pytest = "*"
+psutil = "*"
+

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,255 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b5442e59953ad9755f1bec439ee55f8ab3dba4a19e750eaf96f77bb4f60e8844"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
+            ],
+            "index": "pypi",
+            "version": "==3.0.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "index": "pypi",
+            "version": "==3.2.0"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:42df03e7797b796625b1029c0400279c7c34fd7df24a7d7818a1abb5b38710dd",
+                "sha256:c68c661ac5cc81058ac94247278eeda6d2e6aecb3e227b0387c30d277e7ef8d4"
+            ],
+            "index": "pypi",
+            "version": "==5.6.0"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.17.3"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7",
+                "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"
+            ],
+            "index": "pypi",
+            "version": "==0.13.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "tabulate": {
+            "hashes": [
+                "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba",
+                "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"
+            ],
+            "index": "pypi",
+            "version": "==0.8.7"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64",
+                "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131",
+                "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c",
+                "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6",
+                "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023",
+                "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df",
+                "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394",
+                "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4",
+                "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b",
+                "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2",
+                "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d",
+                "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65",
+                "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d",
+                "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef",
+                "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7",
+                "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60",
+                "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6",
+                "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8",
+                "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b",
+                "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d",
+                "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac",
+                "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935",
+                "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d",
+                "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28",
+                "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876",
+                "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0",
+                "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3",
+                "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"
+            ],
+            "index": "pypi",
+            "version": "==5.8.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "index": "pypi",
+            "version": "==6.2.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        }
+    }
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pipenv>=2018.11.26
 psutil==5.7.2
+pytest==6.2.*

--- a/rkd/standardlib/core.py
+++ b/rkd/standardlib/core.py
@@ -16,9 +16,9 @@ from ..api.contract import ArgparseArgument
 from ..api.syntax import TaskDeclaration
 from ..inputoutput import clear_formatting
 from ..aliasgroups import parse_alias_groups_from_env, AliasGroup
-from .shell import ShellCommandTask
 from ..packaging import find_resource_directory
-from rkd import env
+from .. import env
+from .shell import ShellCommandTask
 
 
 class InitTask(TaskInterface):

--- a/rkd/taskutil.py
+++ b/rkd/taskutil.py
@@ -46,7 +46,7 @@ class TaskUtilities(AbstractClass):
         binary = sys.argv[0]
         sys_executable_basename = os.path.basename(sys.executable)
 
-        if "-m unittest" in binary:
+        if "-m unittest" in binary or "pytest" in binary:
             return binary.split(' ')[0] + ' -m rkd'
 
         # as a Python module: "python -m rkd" for example

--- a/rkd/test.py
+++ b/rkd/test.py
@@ -16,12 +16,13 @@ from .standardlib import CallableTask
 from .api.inputoutput import NullSystemIO
 
 
-class TestTask(CallableTask):
+class TaskForTesting(CallableTask):
     _description = 'Test task for automated tests'
     _become: str = False
 
     def __init__(self):
         self._io = NullSystemIO()
+        super().__init__(':test', None)
 
     def get_name(self) -> str:
         return ':test'
@@ -42,7 +43,7 @@ class TestTask(CallableTask):
         }
 
 
-class TestTaskWithRKDCallInside(TestTask):
+class TaskForTestingWithRKDCallInside(TaskForTesting):
     def execute(self, context: ExecutionContext) -> bool:
         self.rkd([':sh', '-c', '"echo \'9 Aug 2014 Michael Brown, an unarmed Black teenager, was killed by a white police officer in Ferguson, Missouri, sparking mass protests across the US.\'"'])
         return True
@@ -50,7 +51,7 @@ class TestTaskWithRKDCallInside(TestTask):
 
 def get_test_declaration(task: TaskInterface = None) -> TaskDeclaration:
     if not task:
-        task = TestTask()
+        task = TaskForTesting()
 
     return TaskDeclaration(task, {}, [])
 

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -14,7 +14,7 @@ from rkd.api.syntax import TaskDeclaration
 from rkd.api.syntax import TaskAliasDeclaration
 from rkd.api.syntax import GroupDeclaration
 from rkd.api.testing import BasicTestingCase
-from rkd.test import TestTask
+from rkd.test import TaskForTesting
 from rkd.standardlib import InitTask
 
 CURRENT_SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -149,7 +149,7 @@ class ContextTest(BasicTestingCase):
         """A successful case for distinct_imports()"""
 
         imports, aliases = distinct_imports('hello', [
-            TaskDeclaration(TestTask()),
+            TaskDeclaration(TaskForTesting()),
             TaskAliasDeclaration(':hello', [':test'])
         ])
 

--- a/test/test_contract_task_interface.py
+++ b/test/test_contract_task_interface.py
@@ -4,7 +4,7 @@ import unittest
 import os
 
 from rkd.api.testing import BasicTestingCase
-from rkd.test import TestTask
+from rkd.test import TaskForTesting
 from rkd.contract import ArgumentEnv
 
 CURRENT_SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -16,7 +16,7 @@ class TestTaskInterface(BasicTestingCase):
         will be tested already, but we need to check there if the interface matches
         """
 
-        task = TestTask()
+        task = TaskForTesting()
         out = task.table(
             header=['Activist', 'Born date'],
             body=[
@@ -34,7 +34,7 @@ class TestTaskInterface(BasicTestingCase):
         self.assertIn('Born date', out)
 
     def test_should_fork(self):
-        task = TestTask()
+        task = TaskForTesting()
 
         with self.subTest('Will fork'):
             task.get_become_as = lambda: 'root'
@@ -45,7 +45,7 @@ class TestTaskInterface(BasicTestingCase):
             self.assertFalse(task.should_fork())
 
     def test_internal_normalized_get_declared_envs_maps_primitive_types_into_class_instances(self):
-        task = TestTask()
+        task = TaskForTesting()
         task.get_declared_envs = lambda: {
             'SOME_ENV': 'primitive',
             'SOME_OTHER_ENV': ArgumentEnv(name='SOME_OTHER_ENV', switch='--cmd', default='not primitive')
@@ -63,7 +63,7 @@ class TestTaskInterface(BasicTestingCase):
             self.assertTrue(isinstance(normalized['SOME_OTHER_ENV'], ArgumentEnv))
 
     def test_internal_getenv_finds_mapped_environment_variable_by_switch_name(self):
-        task = TestTask()
+        task = TaskForTesting()
         task.get_declared_envs = lambda: {
             'SOME_OTHER_ENV': ArgumentEnv(name='SOME_OTHER_ENV', switch='--cmd', default='not primitive')
         }
@@ -71,7 +71,7 @@ class TestTaskInterface(BasicTestingCase):
         self.assertEqual('not primitive', task.internal_getenv('', envs={}, switch='--cmd'))
 
     def test_internal_getenv_finds_envronment_variable_by_its_not_mapped_name(self):
-        task = TestTask()
+        task = TaskForTesting()
         task.get_declared_envs = lambda: {
             'SOME_ENV': 'primitive'
         }

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -16,8 +16,8 @@ from rkd.api.inputoutput import IO
 from rkd.api.contract import ExecutionContext
 from rkd.api.testing import BasicTestingCase
 from rkd.contract import TaskInterface
-from rkd.test import TestTask
-from rkd.test import TestTaskWithRKDCallInside
+from rkd.test import TaskForTesting
+from rkd.test import TaskForTestingWithRKDCallInside
 
 CURRENT_SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 
@@ -26,7 +26,7 @@ class TestOneByOneExecutor(BasicTestingCase):
     @staticmethod
     def _prepare_test_for_forking_process(task: TaskInterface = None):
         if not task:
-            task = TestTask()
+            task = TaskForTesting()
 
         io = IO()
         string_io = StringIO()
@@ -105,7 +105,7 @@ class TestOneByOneExecutor(BasicTestingCase):
         with io.capture_descriptors(stream=string_io, enable_standard_out=False):
             executor._execute_as_forked_process('', task, temp, ctx)
 
-        self.assertIn('Pickle trace: ["[val type=TestTask].should_fork', string_io.getvalue())
+        self.assertIn('Pickle trace: ["[val type=TaskForTesting].should_fork', string_io.getvalue())
         self.assertIn('Cannot fork, serialization failed. Hint: Tasks that are using internally' +
                       ' inner-methods and lambdas cannot be used with become/fork', string_io.getvalue())
 
@@ -116,7 +116,7 @@ class TestOneByOneExecutor(BasicTestingCase):
         # TestTaskWithRKDCallInside() contains a rkd() call inside execute(), that's what we are testing
         # it is invisible in our test. We cannot use lambda to define this in test, because lambdas are not serializable
         #
-        string_io, task, executor, io, ctx, temp = self._prepare_test_for_forking_process(TestTaskWithRKDCallInside())
+        string_io, task, executor, io, ctx, temp = self._prepare_test_for_forking_process(TaskForTestingWithRKDCallInside())
         task.should_fork = ret_true
 
         with io.capture_descriptors(stream=string_io, enable_standard_out=False):

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -263,7 +263,7 @@ class TestFunctional(FunctionalTestingCase):
                 FIRST: "First"
                 SECOND: "Second"
                 THIRD: "Escaped one"
-                ALL: ${FIRST} ${SECOND} \${THIRD}
+                ALL: ${FIRST} ${SECOND} ${THIRD}
             steps: |
                 echo "!!! ${ALL}"
         """

--- a/test/test_inputoutput_env.py
+++ b/test/test_inputoutput_env.py
@@ -13,4 +13,4 @@ class TestIOEnv(BasicTestingCase):
         # get result
         copy = get_environment_copy()
 
-        self.assertEqual('\$SECOND', copy['FIRST'])
+        self.assertEqual("\\$SECOND", copy['FIRST'])

--- a/test/test_inputoutput_wizard.py
+++ b/test/test_inputoutput_wizard.py
@@ -4,13 +4,13 @@ from unittest.mock import mock_open, patch
 from rkd.api.testing import BasicTestingCase
 from rkd.api.inputoutput import Wizard
 from rkd.api.inputoutput import BufferedSystemIO
-from rkd.test import TestTask
+from rkd.test import TaskForTesting
 from rkd.exception import InterruptExecution
 
 
 class TestWizard(BasicTestingCase):
     def test_regexp_validation(self):
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.sleep_time = 0
         wizard.io = BufferedSystemIO()
 
@@ -24,7 +24,7 @@ class TestWizard(BasicTestingCase):
             self.assertRaises(InterruptExecution, lambda: wizard.ask('What\'s your name?', 'name', regexp='([A-Za-z]+)'))
 
     def test_input_is_retried_when_validation_fails(self):
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.sleep_time = 0
         wizard.io = BufferedSystemIO()
         self.retry_num = 0
@@ -42,7 +42,7 @@ class TestWizard(BasicTestingCase):
     def test_must_select_between_regexp_and_choice_validation(self):
         """Verify that the 'regexp' and 'choices' cannot be specified at one time in ask()"""
 
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.io = BufferedSystemIO()
 
         self.assertRaises(Exception, lambda:
@@ -53,7 +53,7 @@ class TestWizard(BasicTestingCase):
         )
 
     def test_is_question_pretty_formatted_for_choice_validation(self):
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.io = BufferedSystemIO()
         wizard.input = lambda secret: '1936'
 
@@ -64,7 +64,7 @@ class TestWizard(BasicTestingCase):
         self.assertIn('In which year the Spanish social revolution has begun? [1936, 1910]:', wizard.io.get_value())
 
     def test_is_question_pretty_formatted_for_regexp_validation(self):
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.io = BufferedSystemIO()
         wizard.input = lambda secret: '1936'
 
@@ -75,7 +75,7 @@ class TestWizard(BasicTestingCase):
         self.assertIn('In which year the Spanish social revolution has begun? [([0-9]{4})]:', wizard.io.get_value())
 
     def test_is_question_pretty_formatted_for_default_value_and_choice(self):
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.io = BufferedSystemIO()
         wizard.input = lambda secret: '1936'
 
@@ -91,7 +91,7 @@ class TestWizard(BasicTestingCase):
         rkd_shell_calls = []
 
         with patch('rkd.api.inputoutput.open', tmp_wizard_file, create=True):
-            task = TestTask()
+            task = TaskForTesting()
             task.rkd = lambda *args, **kwargs: rkd_shell_calls.append(args)
 
             wizard = Wizard(task)
@@ -114,7 +114,7 @@ class TestWizard(BasicTestingCase):
     def test_getpass_is_used_when_secret_switch_is_used(self):
         """Test a secret=True switch in wizard.input() which is used by ask()"""
 
-        wizard = Wizard(TestTask())
+        wizard = Wizard(TaskForTesting())
         wizard.io = BufferedSystemIO()
 
         with patch('rkd.api.inputoutput.getpass') as getpass:

--- a/test/test_standardlib_lineinfiletask.py
+++ b/test/test_standardlib_lineinfiletask.py
@@ -148,7 +148,7 @@ class LineInFileTaskTest(BasicTestingCase):
             producirá la revolución.
             Nuestro pendón uno ha de ser:
             sólo en la unión está el vencer.'''.split("\n"),
-            after_line_regexp='(.*)Read\ more(.*)',
+            after_line_regexp='(.*)Read more(.*)',
             only_first_occurrence=True,
             regexp='.*Trabajador.*'
         )

--- a/test/test_taskutil.py
+++ b/test/test_taskutil.py
@@ -4,6 +4,7 @@ import unittest.mock
 import os
 import psutil
 import subprocess
+import warnings
 from tempfile import NamedTemporaryFile
 from collections import OrderedDict
 from io import StringIO
@@ -207,7 +208,7 @@ for i in range(0, 1024 * 128):
 
         with io.capture_descriptors(stream=out, enable_standard_out=False):
             task.sh('env | grep TEST_ENV', env={
-                'TEST_ENV': 'Mikhail\$1Bakunin\$PATHtest',
+                'TEST_ENV': "Mikhail\\$1Bakunin\\$PATHtest",
                 'TEST_ENV_NOT_ESCAPED': 'Hello $TEST_ENV'
             })
 


### PR DESCRIPTION
Using PyTest instead of Unittest as a test runner.
Benefits: Fancy output, test reports, better CLI 

https://github.com/riotkit-org/riotkit-do/runs/2746864995?check_suite_focus=true